### PR TITLE
Add form validation

### DIFF
--- a/web/src/components/Form.js
+++ b/web/src/components/Form.js
@@ -14,6 +14,7 @@ const Form = ({
         name="email"
         id="email"
         placeholder="Your email"
+        type="email"
         value={emailValue}
         onChange={handleChange}
       />

--- a/web/src/container/FormContainer.js
+++ b/web/src/container/FormContainer.js
@@ -12,7 +12,7 @@ class FormContainer extends PureComponent {
     this.state = this.initialState;
 
     this.updateState = this.updateState.bind(this);
-    this.logState = this.logState.bind(this);
+    this.postForm = this.postForm.bind(this);
   }
 
   updateState = e => {
@@ -23,7 +23,7 @@ class FormContainer extends PureComponent {
     console.log('Log:', this.state);
   }
 
-  logState = e => {
+  postForm = e => {
     e.preventDefault();
 
     const validForm = this.validateForm(this.state.email, this.state.message);
@@ -58,7 +58,7 @@ class FormContainer extends PureComponent {
     return (
       <Form
         handleChange={this.updateState}
-        handleSubmit={this.logState}
+        handleSubmit={this.postForm}
         emailValue={this.state.email}
         messageValue={this.state.message}
       />

--- a/web/src/container/FormContainer.js
+++ b/web/src/container/FormContainer.js
@@ -26,8 +26,33 @@ class FormContainer extends PureComponent {
   logState = e => {
     e.preventDefault();
 
-    console.log('State:', this.state);
+    const validForm = this.validateForm(this.state.email, this.state.message);
+
+    if (validForm) {
+      console.log('Successfully posted:', this.state);
+    }
   }
+
+  validateForm = (email, message) => {
+    const formFilled = email !== '' && message !== '';
+    const validEmail = this.validateEmail(email);
+
+    try {
+      if (!validEmail) throw new Error('Please enter a valid email address.');
+      if (!formFilled) throw new Error('Please fill in the email and message fields.');
+
+      return true;
+    }
+    catch(err) {
+      console.log(err);
+      return false;
+    }
+  }
+
+  validateEmail = email => {
+    const emailRegex = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/igm;
+    return emailRegex.test(email);
+  };
 
   render() {
     return (


### PR DESCRIPTION
## PR purpose

Add 2 types of form validation:

1. Email and message fields must both be filled before posting
1. Given email must be a valid email address

## PR changes

- [x] Rename `logState()` to `postForm()` to reflect intended purpose of the function attached to the form submit event.
- [x] Add `validateEmail()` function
- [x] Add `validateForm()` function which throws error if either `validateEmail()` is false or if either the email or the message field is not filled.
- [x] Use `validateForm()` on `postForm()`
- [x] Add `type="email"` attribute to email field for additional browser-included validation