### PR TITLE
Add POST form function

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,15 @@ yarn start
 ```
 
 Open http://localhost:3000/ to view the contact form app (unless your CLI provides a different address).
-
+View `console.log` outputs by opening the Console panel on Chrome or other browser.
 
 ## Other information
 
 - I used [Create React App](https://github.com/facebookincubator/create-react-app) to bootstrap the app.
 - Attempt to write basic tests, but [Enzyme 3 has some breaking changes](https://github.com/facebookincubator/create-react-app/issues/3206) requiring further configuration.
+- I’ve left in `console.log`s so you can view when functions are being called in the console panel and their resulting output.
+
+## Challenges
+
+- Unfortunately, was unable to figure out how to connect the React app with the endpoint the php mock server.
+- The contact form needs more comprehensive unit testing.

--- a/web/src/container/FormContainer.js
+++ b/web/src/container/FormContainer.js
@@ -29,8 +29,40 @@ class FormContainer extends PureComponent {
     const validForm = this.validateForm(this.state.email, this.state.message);
 
     if (validForm) {
-      console.log('Successfully posted:', this.state);
+      const payload = {
+        "data" : {
+          "type": "contact-message",
+          "attributes": this.state
+        }
+      }
+      console.log('Payload:', payload);
+      this.postToApi(payload);
     }
+  }
+
+  postToApi = payload => {
+    const init = {
+      method: 'POST',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*'
+      },
+      body: JSON.stringify(payload)
+    }
+
+    return fetch("http://notsure.com/what/endpoint", init)
+    .then((response) => {
+      if (!response.ok) {
+        throw Error(response.statusText);
+      }
+
+      console.log("Form posted!", init);
+      this.setState(this.initialState);
+      return response;
+    }).catch(err => {
+      console.log(err);
+    });
   }
 
   validateForm = (email, message) => {


### PR DESCRIPTION
## PR purpose

Attempt to send a `POST` request to an endpoint on clicking the Submit button. Unfortunately, not too sure how to identify what endpoint corresponds to the mock php server and so functionality is incomplete.

## PR changes

- [x] Modify `postForm` to prepare the payload structure using the component’s state and call another function `postToApi`.
- [x] Create `postToApi` function which makes a fetch to an example endpoint.
- [x] Update README to reflect that the postToApi functionality is incomplete