### PR TITLE
Fix POST request made by Form

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,7 @@ First, install [yarn](https://yarnpkg.com/lang/en/docs/install/) and use [nvm](h
 ```bash
 nvm install node
 nvm use node
-cd api
-php
-cd ..
+php server
 cd web
 yarn
 yarn start
@@ -52,5 +50,4 @@ View `console.log` outputs by opening the Console panel on Chrome or other brows
 
 ## Challenges
 
-- Unfortunately, was unable to figure out how to connect the React app with the endpoint the php mock server.
 - The contact form needs more comprehensive unit testing.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ First, install [yarn](https://yarnpkg.com/lang/en/docs/install/) and use [nvm](h
 ```bash
 nvm install node
 nvm use node
-php server
+php -S localhost:5000 -t ./api
 cd web
 yarn
 yarn start

--- a/web/src/container/FormContainer.js
+++ b/web/src/container/FormContainer.js
@@ -44,14 +44,12 @@ class FormContainer extends PureComponent {
     const init = {
       method: 'POST',
       headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*'
+        'Accept': 'application/json'
       },
       body: JSON.stringify(payload)
     }
 
-    return fetch("http://notsure.com/what/endpoint", init)
+    return fetch("http://localhost:5000", init)
     .then((response) => {
       if (!response.ok) {
         throw Error(response.statusText);
@@ -59,6 +57,7 @@ class FormContainer extends PureComponent {
 
       console.log("Form posted!", init);
       this.setState(this.initialState);
+      console.log("Response", response);
       return response;
     }).catch(err => {
       console.log(err);


### PR DESCRIPTION
## PR purpose

Identified how to properly run php mock server and send POST request to it. Made changes to the `FormContainer`’s `postToApi` function to get it to successfully send POST requests to the mock server.

## PR changes

- [x] Direct the `postToApi` fetch request to the correct endpoint
- [x] Remove headers that are disallowed by `Access-Control-Allow-Headers` in preflight response
- [x] Update README on correct instructions to run the php server and remove mention of the failure to connect the contact form app to the php server
